### PR TITLE
fix: attribute error when view is not ready / can not be access

### DIFF
--- a/source/lib/dynamic_list.py
+++ b/source/lib/dynamic_list.py
@@ -18,10 +18,11 @@ AssetItems = tuple[tuple[str, str, int, bool], ...]
 
 
 def _iface_lang(context) -> str:
-    view = context.preferences.view
+    if hasattr(context.preferences,'view'):
+        view = context.preferences.view
 
-    if view.use_translate_interface:
-        return view.language
+        if view.use_translate_interface:
+            return view.language
 
     return "en_US"
 


### PR DESCRIPTION
when using with `pie menu editor`, sometime it will cause 
```
File "C:\Program Files (x86)\Steam\steamapps\common\Blender\portable\scripts\addons\jewelcraft\lib\dynamic_list.py", line 21, in _iface_lang
    view = context.preferences.view
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'preferences'
```
Make this pr to fix it @mrachinskiy 