### PR TITLE
Incremental Resize Tool

### DIFF
--- a/source/lib/view3d_lib/view3d_text.py
+++ b/source/lib/view3d_lib/view3d_text.py
@@ -11,6 +11,7 @@ _TYPE_BOOL = 1
 _TYPE_INT = 2
 _TYPE_PROC = 3
 _TYPE_ENUM = 4
+_TYPE_HOTKEY = 5
 
 
 class _Prop(NamedTuple):
@@ -64,6 +65,9 @@ class Layout:
 
     def enum(self, name: str, key: str, attr: str, items: tuple[str]) -> None:
         self._prop(_TYPE_ENUM, name, key, attr, items)
+
+    def hotkey(self, name: str, key: str) -> None:
+        self._prop(_TYPE_HOTKEY, name, key, "", None)
 
 
 def _get_font_scale(prefs: bpy.types.Preferences) -> float:
@@ -180,7 +184,7 @@ def draw_options(data, layout: Layout, x: int, y: int) -> None:
             _x += 20
             blf.position(fontid, _x, y, 0.0)
             blf.color(fontid, *color_blue)
-            blf.draw(fontid, str(round(getattr(data, prop.attr), 1)))
+            blf.draw(fontid, str(round(getattr(data, prop.attr), 3)))
 
         elif prop.type is _TYPE_ENUM:
             _x += w_col2 + 10

--- a/source/operators/object.py
+++ b/source/operators/object.py
@@ -758,8 +758,6 @@ class OBJECT_OT_resize(Operator):
         return {"FINISHED"}
 
     def invoke(self, context, event):
-        from ..lib import asset
-
         if not context.object:
             return {"CANCELLED"}
 
@@ -769,6 +767,219 @@ class OBJECT_OT_resize(Operator):
 
         wm = context.window_manager
         return wm.invoke_props_dialog(self)
+
+
+class OBJECT_OT_increment_size(Operator):
+    bl_label = "Increment Size"
+    bl_description = "Scale selected objects to given size"
+    bl_idname = "object.jewelcraft_increment_size"
+    bl_options = {"REGISTER", "UNDO"}
+
+    dims_orig: dict[str, tuple[float, float, float]]
+
+    axis: EnumProperty(
+        name="Axis",
+        items=(
+            ("0", "X", ""),
+            ("1", "Y", ""),
+            ("2", "Z", ""),
+        ),
+    )
+    step: FloatProperty(name="Increment", step=10, unit="LENGTH", default=0.1)
+    min: FloatProperty(name="Min", step=10, unit="LENGTH", default=0.8)
+    max: FloatProperty(name="Max", step=10, unit="LENGTH", default=3.0)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.separator()
+
+        col = layout.column()
+        col.row().prop(self, "axis", expand=True)
+        col.prop(self, "step")
+        row = col.row(align=True)
+        row.prop(self, "min", text="Clamp")
+        row.prop(self, "max", text="")
+
+        layout.separator()
+
+    def execute(self, context):
+        axis = int(self.axis)
+        neg = self.step < 0.0
+
+        for ob in context.selected_objects:
+            size_orig = self.dims_orig[ob.name][axis]
+
+            if (neg and size_orig < self.min) or (not neg and size_orig > self.max):
+                continue
+
+            scale = (size_orig + self.step) / size_orig
+            size_new = size_orig * scale
+
+            if neg and size_new < self.min:
+                scale = self.min / size_orig
+            elif not neg and size_new > self.max:
+                scale = self.max / size_orig
+
+            ob.scale *= scale
+
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        obs = context.selected_objects
+        if not obs:
+            return {"CANCELLED"}
+
+        self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in obs}
+        return self.execute(context)
+
+
+class OBJECT_OT_increment_size_modal(Operator):
+    bl_label = "Increment Size Modal"
+    bl_description = "Scale selected objects to given size"
+    bl_idname = "object.jewelcraft_increment_size_modal"
+    bl_options = {"REGISTER", "UNDO"}
+
+    is_running = False
+    dims_orig: dict[str, tuple[float, float, float]]
+
+    axis: EnumProperty(
+        name="Axis",
+        items=(
+            ("0", "X", ""),
+            ("1", "Y", ""),
+            ("2", "Z", ""),
+        ),
+    )
+    step: FloatProperty(name="Increment", step=10, unit="LENGTH", default=0.1)
+    min: FloatProperty(name="Min", step=10, unit="LENGTH", default=0.8)
+    max: FloatProperty(name="Max", step=10, unit="LENGTH", default=3.0)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.separator()
+
+        col = layout.column()
+        col.row().prop(self, "axis", expand=True)
+        col.prop(self, "step")
+        row = col.row(align=True)
+        row.prop(self, "min", text="Clamp")
+        row.prop(self, "max", text="")
+
+        layout.separator()
+
+    def modal(self, context, event):
+        if event.type in {"ESC", "RET", "SPACE", "NUMPAD_ENTER"}:
+            bpy.types.SpaceView3D.draw_handler_remove(self.handler_text, "WINDOW")
+            self.__class__.is_running = False
+            context.workspace.status_text_set(None)
+            self.region.tag_redraw()
+            return {"FINISHED"}
+
+        elif event.type == "WHEELUPMOUSE" and event.value == "PRESS":
+            self.step = 0.1
+            self.execute(context)
+            self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in context.selected_objects}
+            self.region.tag_redraw()
+            return {"RUNNING_MODAL"}
+
+        elif event.type == "WHEELDOWNMOUSE" and event.value == "PRESS":
+            self.step = -0.1
+            self.execute(context)
+            self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in context.selected_objects}
+            self.region.tag_redraw()
+            return {"RUNNING_MODAL"}
+
+        elif event.type == "RIGHT_BRACKET" and event.value == "PRESS":
+            self.min += 0.1
+            self.region.tag_redraw()
+            return {"RUNNING_MODAL"}
+
+        elif event.type == "LEFT_BRACKET" and event.value == "PRESS":
+            self.min -= 0.1
+            self.region.tag_redraw()
+            return {"RUNNING_MODAL"}
+
+        elif event.type == "PERIOD" and event.value == "PRESS":
+            self.max += 0.1
+            self.region.tag_redraw()
+            return {"RUNNING_MODAL"}
+
+        elif event.type == "COMMA" and event.value == "PRESS":
+            self.max -= 0.1
+            self.region.tag_redraw()
+            return {"RUNNING_MODAL"}
+
+        return {"PASS_THROUGH"}
+
+    def execute(self, context):
+        axis = int(self.axis)
+        neg = self.step < 0.0
+
+        for ob in context.selected_objects:
+            size_orig = self.dims_orig[ob.name][axis]
+
+            if (neg and size_orig < self.min) or (not neg and size_orig > self.max):
+                continue
+
+            scale = (size_orig + self.step) / size_orig
+            size_new = size_orig * scale
+
+            if neg and size_new < self.min:
+                scale = self.min / size_orig
+            elif not neg and size_new > self.max:
+                scale = self.max / size_orig
+
+            ob.scale *= scale
+
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        from ..lib import view3d_lib
+        from .gem_map import onscreen
+
+        if self.__class__.is_running:
+            self.report({"ERROR"}, "Operator already running")
+            return {"CANCELLED"}
+
+        if context.area.type != "VIEW_3D":
+            self.report({"ERROR"}, "Area type is not 3D View")
+            return {"CANCELLED"}
+
+        obs = context.selected_objects
+        if not obs:
+            return {"CANCELLED"}
+
+        self.__class__.is_running = True
+        self.region = context.region
+
+        self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in obs}
+
+        context.window_manager.modal_handler_add(self)
+        context.workspace.status_text_set("ESC/↵/␣: Exit")
+
+        # 3D View Options
+        # ----------------------------
+
+        lay = view3d_lib.Layout()
+        lay.int(_("Size"), "(MDown/MUp)", "step")
+        lay.int(_("Min"), "([/])", "min")
+        lay.int(_("Max"), "(</>)", "max")
+
+        self.handler_text = bpy.types.SpaceView3D.draw_handler_add(
+            view3d_lib.draw_options,
+            (self, lay, *view3d_lib.get_xy()),
+            "WINDOW",
+            "POST_PIXEL",
+        )
+
+        self.region.tag_redraw()
+        return {'RUNNING_MODAL'}
 
 
 class CURVE_OT_length_display(Operator):

--- a/source/operators/object.py
+++ b/source/operators/object.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2015-2025 Mikhail Rachinskiy
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from math import pi, tau
+from math import pi, tau, modf
 
 import bpy
 from bpy.app.translations import pgettext_iface as _
@@ -769,179 +769,158 @@ class OBJECT_OT_resize(Operator):
         return wm.invoke_props_dialog(self)
 
 
-class OBJECT_OT_increment_size(Operator):
-    bl_label = "Increment Size"
+def _fraction_step(value: float, step: float) -> float:
+    f, i = modf(value)
+    return i + (round(f / step) * step)
+
+
+class OBJECT_OT_incremental_resize(Operator):
+    bl_label = "Incremental Resize"
     bl_description = "Scale selected objects to given size"
-    bl_idname = "object.jewelcraft_increment_size"
-    bl_options = {"REGISTER", "UNDO"}
-
-    dims_orig: dict[str, tuple[float, float, float]]
-
-    axis: EnumProperty(
-        name="Axis",
-        items=(
-            ("0", "X", ""),
-            ("1", "Y", ""),
-            ("2", "Z", ""),
-        ),
-    )
-    step: FloatProperty(name="Increment", step=10, unit="LENGTH", default=0.1)
-    min: FloatProperty(name="Min", step=10, unit="LENGTH", default=0.8)
-    max: FloatProperty(name="Max", step=10, unit="LENGTH", default=3.0)
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-
-        layout.separator()
-
-        col = layout.column()
-        col.row().prop(self, "axis", expand=True)
-        col.prop(self, "step")
-        row = col.row(align=True)
-        row.prop(self, "min", text="Clamp")
-        row.prop(self, "max", text="")
-
-        layout.separator()
-
-    def execute(self, context):
-        axis = int(self.axis)
-        neg = self.step < 0.0
-
-        for ob in context.selected_objects:
-            size_orig = self.dims_orig[ob.name][axis]
-
-            if (neg and size_orig < self.min) or (not neg and size_orig > self.max):
-                continue
-
-            scale = (size_orig + self.step) / size_orig
-            size_new = size_orig * scale
-
-            if neg and size_new < self.min:
-                scale = self.min / size_orig
-            elif not neg and size_new > self.max:
-                scale = self.max / size_orig
-
-            ob.scale *= scale
-
-        return {"FINISHED"}
-
-    def invoke(self, context, event):
-        obs = context.selected_objects
-        if not obs:
-            return {"CANCELLED"}
-
-        self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in obs}
-        return self.execute(context)
-
-
-class OBJECT_OT_increment_size_modal(Operator):
-    bl_label = "Increment Size Modal"
-    bl_description = "Scale selected objects to given size"
-    bl_idname = "object.jewelcraft_increment_size_modal"
+    bl_idname = "object.jewelcraft_incremental_resize"
     bl_options = {"REGISTER", "UNDO"}
 
     is_running = False
-    dims_orig: dict[str, tuple[float, float, float]]
+    handler_text = None
+    filter_gems = False
 
-    axis: EnumProperty(
-        name="Axis",
-        items=(
-            ("0", "X", ""),
-            ("1", "Y", ""),
-            ("2", "Z", ""),
-        ),
-    )
-    step: FloatProperty(name="Increment", step=10, unit="LENGTH", default=0.1)
-    min: FloatProperty(name="Min", step=10, unit="LENGTH", default=0.8)
-    max: FloatProperty(name="Max", step=10, unit="LENGTH", default=3.0)
+    axis: IntProperty(min=0, max=2)
 
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
+    step: FloatProperty(min=0.0, default=0.1)
+    min: FloatProperty(min=0.0, default=0.3)
+    max: FloatProperty(min=0.0, default=1.0)
 
-        layout.separator()
-
-        col = layout.column()
-        col.row().prop(self, "axis", expand=True)
-        col.prop(self, "step")
-        row = col.row(align=True)
-        row.prop(self, "min", text="Clamp")
-        row.prop(self, "max", text="")
-
-        layout.separator()
+    gem_step: FloatProperty(min=0.0, default=0.1)
+    gem_min: FloatProperty(min=0.0, default=0.8)
+    gem_max: FloatProperty(min=0.0, default=3.0)
 
     def modal(self, context, event):
         if event.type in {"ESC", "RET", "SPACE", "NUMPAD_ENTER"}:
-            bpy.types.SpaceView3D.draw_handler_remove(self.handler_text, "WINDOW")
             self.__class__.is_running = False
+            bpy.types.SpaceView3D.draw_handler_remove(self.handler_text, "WINDOW")
             context.workspace.status_text_set(None)
-            self.region.tag_redraw()
+            context.region.tag_redraw()
             return {"FINISHED"}
 
-        elif event.type == "WHEELUPMOUSE" and event.value == "PRESS":
-            self.step = 0.1
-            self.execute(context)
-            self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in context.selected_objects}
-            self.region.tag_redraw()
+        elif event.type == "F" and event.value == "PRESS":
+            self.filter_gems = not self.filter_gems
+            context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
-        elif event.type == "WHEELDOWNMOUSE" and event.value == "PRESS":
-            self.step = -0.1
-            self.execute(context)
-            self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in context.selected_objects}
-            self.region.tag_redraw()
+        elif event.type in {"LEFT_ARROW", "RIGHT_ARROW"} and event.value == "PRESS":
+            if event.type == "LEFT_ARROW":
+                self.axis -= 1
+            else:
+                self.axis += 1
+            context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
-        elif event.type == "RIGHT_BRACKET" and event.value == "PRESS":
-            self.min += 0.1
-            self.region.tag_redraw()
+        elif event.type in {"MINUS", "EQUAL"} and event.value == "PRESS":
+            if event.type == "MINUS":
+                if event.alt:
+                    if event.shift:
+                        self.step -= 0.01
+                    else:
+                        self.step -= 0.1
+                else:
+                    if event.shift:
+                        self.gem_step -= 0.01
+                    else:
+                        self.gem_step -= 0.1
+            else:
+                if event.alt:
+                    if event.shift:
+                        self.step += 0.01
+                    else:
+                        self.step += 0.1
+                else:
+                    if event.shift:
+                        self.gem_step += 0.01
+                    else:
+                        self.gem_step += 0.1
+
+            context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
-        elif event.type == "LEFT_BRACKET" and event.value == "PRESS":
-            self.min -= 0.1
-            self.region.tag_redraw()
+        elif event.type in {"LEFT_BRACKET", "RIGHT_BRACKET"} and event.value == "PRESS":
+            if event.type == "LEFT_BRACKET":
+                if event.alt:
+                    self.min -= 0.1
+                else:
+                    self.gem_min -= 0.1
+            else:
+                if event.alt:
+                    self.min += 0.1
+                else:
+                    self.gem_min += 0.1
+            context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
-        elif event.type == "PERIOD" and event.value == "PRESS":
-            self.max += 0.1
-            self.region.tag_redraw()
+        elif event.type in {"COMMA", "PERIOD"} and event.value == "PRESS":
+            if event.type == "COMMA":
+                if event.alt:
+                    self.max -= 0.1
+                else:
+                    self.gem_max -= 0.1
+            else:
+                if event.alt:
+                    self.max += 0.1
+                else:
+                    self.gem_max += 0.1
+            context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
-        elif event.type == "COMMA" and event.value == "PRESS":
-            self.max -= 0.1
-            self.region.tag_redraw()
+        elif not context.selected_objects:
+            pass
+
+        elif event.type in {"WHEELDOWNMOUSE", "WHEELUPMOUSE"} and event.value == "PRESS":
+            if event.type == "WHEELDOWNMOUSE":
+                self.execute_modal(context, neg=True)
+            else:
+                self.execute_modal(context)
+            context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
         return {"PASS_THROUGH"}
 
-    def execute(self, context):
-        axis = int(self.axis)
-        neg = self.step < 0.0
+    def execute_modal(self, context, neg=False):
+        from ..lib import unit
+
+        if unit._eq(self.gem_step, 0.0) or unit._eq(self.step, 0.0):
+            return
 
         for ob in context.selected_objects:
-            size_orig = ob.dimensions[axis]
+            if "gem" in ob:
+                _step = -self.gem_step if neg else self.gem_step
+                _min = self.gem_min
+                _max = self.gem_max
+            else:
+                if self.filter_gems:
+                    continue
+                _step = -self.step if neg else self.step
+                _min = self.min
+                _max = self.max
 
-            if (neg and size_orig < self.min) or (not neg and size_orig > self.max):
+            size_orig = ob.dimensions[self.axis]
+
+            if (neg and size_orig < _min) or (not neg and size_orig > _max):
                 continue
 
-            scale = (size_orig + self.step) / size_orig
-            size_new = size_orig * scale
+            size_new = _fraction_step(size_orig, _step)
+            size_new = _fraction_step(size_new + _step, _step)
+            scale = size_new / size_orig
 
-            if neg and size_new < self.min:
-                scale = self.min / size_orig
-            elif not neg and size_new > self.max:
-                scale = self.max / size_orig
+            if neg and size_new < _min:
+                scale = _min / size_orig
+            elif not neg and size_new > _max:
+                scale = _max / size_orig
 
             ob.scale *= scale
 
-        return {"FINISHED"}
+        context.view_layer.update()
 
     def invoke(self, context, event):
         from ..lib import view3d_lib
-        from .gem_map import onscreen
 
         if self.__class__.is_running:
             self.report({"ERROR"}, "Operator already running")
@@ -951,14 +930,7 @@ class OBJECT_OT_increment_size_modal(Operator):
             self.report({"ERROR"}, "Area type is not 3D View")
             return {"CANCELLED"}
 
-        obs = context.selected_objects
-        if not obs:
-            return {"CANCELLED"}
-
         self.__class__.is_running = True
-        self.region = context.region
-
-        self.dims_orig = {ob.name: ob.dimensions.to_tuple() for ob in obs}
 
         context.window_manager.modal_handler_add(self)
         context.workspace.status_text_set("ESC/↵/␣: Exit")
@@ -967,9 +939,20 @@ class OBJECT_OT_increment_size_modal(Operator):
         # ----------------------------
 
         lay = view3d_lib.Layout()
-        lay.int(_("Size"), "(MDown/MUp)", "step")
-        lay.int(_("Min"), "([/])", "min")
-        lay.int(_("Max"), "(</>)", "max")
+        lay.hotkey(_("Exit"), "(Esc)")
+        lay.hotkey(_("Resize"), "(Mouse Wheel)")
+        lay.separator()
+        lay.bool(_("Gems Only"), "(F)", "filter_gems")
+        lay.enum(_("Axis"), "(←/→)", "axis", (_("X"), _("Y"), _("Z")))
+        lay.separator()
+        lay.int(_("Step"), "(Alt -/+)", "step")
+        lay.int(_("Min"), "(Alt [/])", "min")
+        lay.int(_("Max"), "(Alt </>)", "max")
+        lay.separator()
+        lay.hotkey(_("Gems"), "")
+        lay.int(_("Step"), "(-/+)", "gem_step")
+        lay.int(_("Min"), "([/])", "gem_min")
+        lay.int(_("Max"), "(</>)", "gem_max")
 
         self.handler_text = bpy.types.SpaceView3D.draw_handler_add(
             view3d_lib.draw_options,
@@ -978,8 +961,8 @@ class OBJECT_OT_increment_size_modal(Operator):
             "POST_PIXEL",
         )
 
-        self.region.tag_redraw()
-        return {'RUNNING_MODAL'}
+        context.region.tag_redraw()
+        return {"RUNNING_MODAL"}
 
 
 class CURVE_OT_length_display(Operator):

--- a/source/operators/object.py
+++ b/source/operators/object.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2015-2025 Mikhail Rachinskiy
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from math import pi, tau, modf
+from math import modf, pi, tau
 
 import bpy
 from bpy.app.translations import pgettext_iface as _
@@ -9,6 +9,7 @@ from bpy.props import BoolProperty, EnumProperty, FloatProperty, IntProperty, St
 from bpy.types import Object, Operator
 from mathutils import Matrix
 
+from .. import var
 from ..lib import unit
 
 
@@ -776,25 +777,30 @@ def _fraction_step(value: float, step: float) -> float:
 
 class OBJECT_OT_incremental_resize(Operator):
     bl_label = "Incremental Resize"
-    bl_description = "Scale selected objects to given size"
+    bl_description = "Individually scale selected objects by given increment"
     bl_idname = "object.jewelcraft_incremental_resize"
     bl_options = {"REGISTER", "UNDO"}
 
     is_running = False
+    first_run = True
     handler_text = None
-    filter_gems = False
 
+    filter_gems = False
     axis: IntProperty(min=0, max=2)
 
     step: FloatProperty(min=0.0, default=0.1)
     min: FloatProperty(min=0.0, default=0.3)
     max: FloatProperty(min=0.0, default=1.0)
-
     gem_step: FloatProperty(min=0.0, default=0.1)
     gem_min: FloatProperty(min=0.0, default=0.8)
     gem_max: FloatProperty(min=0.0, default=3.0)
 
     def modal(self, context, event):
+        if event.shift:
+            value = 0.01
+        else:
+            value = 0.1
+
         if event.type in {"ESC", "RET", "SPACE", "NUMPAD_ENTER"}:
             self.__class__.is_running = False
             bpy.types.SpaceView3D.draw_handler_remove(self.handler_text, "WINDOW")
@@ -818,26 +824,14 @@ class OBJECT_OT_incremental_resize(Operator):
         elif event.type in {"MINUS", "EQUAL"} and event.value == "PRESS":
             if event.type == "MINUS":
                 if event.alt:
-                    if event.shift:
-                        self.step -= 0.01
-                    else:
-                        self.step -= 0.1
+                    self.step -= value
                 else:
-                    if event.shift:
-                        self.gem_step -= 0.01
-                    else:
-                        self.gem_step -= 0.1
+                    self.gem_step -= value
             else:
                 if event.alt:
-                    if event.shift:
-                        self.step += 0.01
-                    else:
-                        self.step += 0.1
+                    self.step += value
                 else:
-                    if event.shift:
-                        self.gem_step += 0.01
-                    else:
-                        self.gem_step += 0.1
+                    self.gem_step += value
 
             context.region.tag_redraw()
             return {"RUNNING_MODAL"}
@@ -845,28 +839,28 @@ class OBJECT_OT_incremental_resize(Operator):
         elif event.type in {"LEFT_BRACKET", "RIGHT_BRACKET"} and event.value == "PRESS":
             if event.type == "LEFT_BRACKET":
                 if event.alt:
-                    self.min -= 0.1
+                    self.min -= value
                 else:
-                    self.gem_min -= 0.1
+                    self.gem_min -= value
             else:
                 if event.alt:
-                    self.min += 0.1
+                    self.min += value
                 else:
-                    self.gem_min += 0.1
+                    self.gem_min += value
             context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
         elif event.type in {"COMMA", "PERIOD"} and event.value == "PRESS":
             if event.type == "COMMA":
                 if event.alt:
-                    self.max -= 0.1
+                    self.max -= value
                 else:
-                    self.gem_max -= 0.1
+                    self.gem_max -= value
             else:
                 if event.alt:
-                    self.max += 0.1
+                    self.max += value
                 else:
-                    self.gem_max += 0.1
+                    self.gem_max += value
             context.region.tag_redraw()
             return {"RUNNING_MODAL"}
 
@@ -932,6 +926,16 @@ class OBJECT_OT_incremental_resize(Operator):
 
         self.__class__.is_running = True
 
+        if self.__class__.first_run:
+            self.__class__.first_run = False
+            prefs = context.preferences.addons[var.ADDON_ID].preferences
+            self.gem_step = prefs.resize_gem_step
+            self.gem_min = prefs.resize_gem_min
+            self.gem_max = prefs.resize_gem_max
+            self.step = prefs.resize_step
+            self.min = prefs.resize_min
+            self.max = prefs.resize_max
+
         context.window_manager.modal_handler_add(self)
         context.workspace.status_text_set("ESC/↵/␣: Exit")
 
@@ -945,14 +949,15 @@ class OBJECT_OT_incremental_resize(Operator):
         lay.bool(_("Gems Only"), "(F)", "filter_gems")
         lay.enum(_("Axis"), "(←/→)", "axis", (_("X"), _("Y"), _("Z")))
         lay.separator()
-        lay.int(_("Step"), "(Alt -/+)", "step")
-        lay.int(_("Min"), "(Alt [/])", "min")
-        lay.int(_("Max"), "(Alt </>)", "max")
-        lay.separator()
         lay.hotkey(_("Gems"), "")
         lay.int(_("Step"), "(-/+)", "gem_step")
         lay.int(_("Min"), "([/])", "gem_min")
         lay.int(_("Max"), "(</>)", "gem_max")
+        lay.separator()
+        lay.hotkey(_("Other"), "")
+        lay.int(_("Step"), "(Alt -/+)", "step")
+        lay.int(_("Min"), "(Alt [/])", "min")
+        lay.int(_("Max"), "(Alt </>)", "max")
 
         self.handler_text = bpy.types.SpaceView3D.draw_handler_add(
             view3d_lib.draw_options,

--- a/source/operators/object.py
+++ b/source/operators/object.py
@@ -922,7 +922,7 @@ class OBJECT_OT_increment_size_modal(Operator):
         neg = self.step < 0.0
 
         for ob in context.selected_objects:
-            size_orig = self.dims_orig[ob.name][axis]
+            size_orig = ob.dimensions[axis]
 
             if (neg and size_orig < self.min) or (not neg and size_orig > self.max):
                 continue

--- a/source/preferences.py
+++ b/source/preferences.py
@@ -590,6 +590,16 @@ class Preferences(ReportLangEnum, AddonPreferences):
         subtype="DIR_PATH",
     )
 
+    # Edit
+    # ------------------------
+
+    resize_gem_step: FloatProperty(name="Step", default=0.1, min=0.0, soft_max=1.0, step=10)
+    resize_gem_min: FloatProperty(name="Min", default=0.8, min=0.0, soft_max=1.0, step=10)
+    resize_gem_max: FloatProperty(name="Max", default=3.0, min=0.0, soft_max=1.0, step=10)
+    resize_step: FloatProperty(name="Step", default=0.1, min=0.0, soft_max=1.0, step=10)
+    resize_min: FloatProperty(name="Min", default=0.3, min=0.0, soft_max=1.0, step=10)
+    resize_max: FloatProperty(name="Max", default=1.0, min=0.0, soft_max=1.0, step=10)
+
     # Asset
     # ------------------------
 
@@ -712,6 +722,7 @@ class Preferences(ReportLangEnum, AddonPreferences):
 class WmProperties(PropertyGroup):
     prefs_show_general: BoolProperty(name="General")
     prefs_show_gems: BoolProperty(name="Gem Colors")
+    prefs_show_edit: BoolProperty(name="Edit")
     prefs_show_asset_manager: BoolProperty(name="Asset Manager")
     prefs_show_design_report: BoolProperty(name="Design Report")
     prefs_show_themes: BoolProperty(name="Themes")

--- a/source/ui.py
+++ b/source/ui.py
@@ -552,10 +552,7 @@ class VIEW3D_PT_jewelcraft_object(SidebarSetup, Panel):
         col.operator("object.jewelcraft_instance_face", icon_value=icon("INSTANCE_FACE"))
 
         layout.operator("object.jewelcraft_resize", icon_value=icon("RESIZE"))
-
-        col = layout.column(align=True)
-        col.operator("object.jewelcraft_increment_size", icon_value=icon("RESIZE"))
-        col.operator("object.jewelcraft_increment_size_modal", icon_value=icon("RESIZE"))
+        layout.operator("object.jewelcraft_incremental_resize", icon_value=icon("RESIZE"))
 
         col = layout.column(align=True)
         col.operator("object.jewelcraft_lattice_project", icon_value=icon("LATTICE_PROJECT"))

--- a/source/ui.py
+++ b/source/ui.py
@@ -554,6 +554,10 @@ class VIEW3D_PT_jewelcraft_object(SidebarSetup, Panel):
         layout.operator("object.jewelcraft_resize", icon_value=icon("RESIZE"))
 
         col = layout.column(align=True)
+        col.operator("object.jewelcraft_increment_size", icon_value=icon("RESIZE"))
+        col.operator("object.jewelcraft_increment_size_modal", icon_value=icon("RESIZE"))
+
+        col = layout.column(align=True)
         col.operator("object.jewelcraft_lattice_project", icon_value=icon("LATTICE_PROJECT"))
         col.operator("object.jewelcraft_lattice_profile", icon_value=icon("LATTICE_PROFILE"))
 

--- a/source/ui.py
+++ b/source/ui.py
@@ -551,8 +551,9 @@ class VIEW3D_PT_jewelcraft_object(SidebarSetup, Panel):
         row.operator("object.jewelcraft_radial_instance", text="Radial", text_ctxt="*", icon_value=icon("RADIAL"))
         col.operator("object.jewelcraft_instance_face", icon_value=icon("INSTANCE_FACE"))
 
-        layout.operator("object.jewelcraft_resize", icon_value=icon("RESIZE"))
-        layout.operator("object.jewelcraft_incremental_resize", icon_value=icon("RESIZE"))
+        row = layout.row(align=True)
+        row.operator("object.jewelcraft_resize", icon_value=icon("RESIZE"))
+        row.operator("object.jewelcraft_incremental_resize", icon_value=icon("RESIZE"), text="Incremental")
 
         col = layout.column(align=True)
         col.operator("object.jewelcraft_lattice_project", icon_value=icon("LATTICE_PROJECT"))
@@ -776,6 +777,23 @@ def prefs_ui(self, context):
         op.prop = "gem_colors"
         op.move_up = True
         sub.operator("wm.jewelcraft_ul_move", text="", icon="TRIA_DOWN").prop = "gem_colors"
+
+    if (panel := _prop_panel(main, wm_props, "prefs_show_edit")):
+        panel.label(text="Incremental Resize")
+
+        panel.label(text="Gems")
+        col = panel.column(align=True)
+        col.prop(self, "resize_gem_step")
+        row = col.row(align=True)
+        row.prop(self, "resize_gem_min", text="Clamp")
+        row.prop(self, "resize_gem_max", text="")
+
+        panel.label(text="Other")
+        col = panel.column(align=True)
+        col.prop(self, "resize_step")
+        row = col.row(align=True)
+        row.prop(self, "resize_min", text="Clamp")
+        row.prop(self, "resize_max", text="")
 
     if (panel := _prop_panel(main, wm_props, "prefs_show_asset_manager")):
         panel.label(text="Libraries")


### PR DESCRIPTION
Introduce Incremental Resize tool, for quick and easy way of resizing selected objects by specified increments.
The tool is implemented as a modal operator, using mouse wheel for individually resizing selected objects.
Step parameters are separated between gems and other objects.
Due to implementation Esc key, that is usually cancels operator, in this case confirms it. But all edits can easily be reverted with a single undo step.

Resize forces final size to be either whole number or in fractional increments. Meaning sizes with step `0.3` will follow this sequence: `0.3, 0.6, 0.9, 1.0, 1.3, 1.6, 1.9, 2.0`